### PR TITLE
handle 404 error by return (not found record) message to the end user

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -4,6 +4,7 @@ namespace App\Exceptions;
 
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Throwable;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class Handler extends ExceptionHandler
 {
@@ -23,8 +24,16 @@ class Handler extends ExceptionHandler
      */
     public function register(): void
     {
-        $this->reportable(function (Throwable $e) {
-            //
-        });
+        // $this->reportable(function (Throwable $e) {
+        //     //
+        // });
+        $this->renderable(function (NotFoundHttpException $e, $request) {
+            if($request->is('api/categories/*') || $request->is('api/products/*') || $request->is('api/users/*') )
+            {
+                  return response()->json([
+                  'message' => 'Record not found.'
+                  ],404);
+                }
+            });
     }
 }


### PR DESCRIPTION
Handle 404 error by return "Not found record" message to the end user,If there are no products,categories or users found.